### PR TITLE
Add GAMESCOPE_CONNECTOR_CONTROL atom

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -46,6 +46,7 @@ bool g_bRotated = false;
 bool g_bUseLayers = true;
 bool g_bDebugLayers = false;
 const char *g_sOutputName = nullptr;
+char* targetConnector = (char*)"eDP-1";
 
 #ifndef DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP
 #define DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP 0x15
@@ -1149,6 +1150,19 @@ static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
 		if (priority < best_priority) {
 			best = conn;
 			best_priority = priority;
+		}
+	}
+
+	for (auto &kv : drm->connectors) {
+		struct connector *conn = &kv.second;
+		drm_log.debugf("force set adapter");
+		drm_log.debugf("conn->name: %s", conn->name);
+		drm_log.debugf("targetConnector: %s", targetConnector);
+		if (strcmp(conn->name, targetConnector) == 0)
+		{
+			drm_log.debugf("target was found!!!");
+			drm_log.infof("  %s (%s)", conn->name, targetConnector);
+			best = conn;
 		}
 	}
 
@@ -2741,6 +2755,12 @@ static bool drm_set_crtc( struct drm_t *drm, struct crtc *crtc )
 	drm->lo_output = lo_output;
 
 	return true;
+}
+
+void drm_set_prefered_connector( struct drm_t *drm, char* name )
+{
+	drm_log.infof("selecting prefered connector %s", name);
+	targetConnector = name;
 }
 
 bool drm_set_connector( struct drm_t *drm, struct connector *conn )

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -46,7 +46,7 @@ bool g_bRotated = false;
 bool g_bUseLayers = true;
 bool g_bDebugLayers = false;
 const char *g_sOutputName = nullptr;
-char* targetConnector = (char*)"eDP-1";
+uint32_t targetConnector;
 
 #ifndef DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP
 #define DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP 0x15
@@ -1155,13 +1155,8 @@ static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
 
 	for (auto &kv : drm->connectors) {
 		struct connector *conn = &kv.second;
-		drm_log.debugf("force set adapter");
-		drm_log.debugf("conn->name: %s", conn->name);
-		drm_log.debugf("targetConnector: %s", targetConnector);
-		if (strcmp(conn->name, targetConnector) == 0)
+		if ( conn->id == targetConnector)
 		{
-			drm_log.debugf("target was found!!!");
-			drm_log.infof("  %s (%s)", conn->name, targetConnector);
 			best = conn;
 		}
 	}
@@ -2757,10 +2752,9 @@ static bool drm_set_crtc( struct drm_t *drm, struct crtc *crtc )
 	return true;
 }
 
-void drm_set_prefered_connector( struct drm_t *drm, char* name )
+void drm_set_prefered_connector( struct drm_t *drm, uint32_t connector_type_id )
 {
-	drm_log.infof("selecting prefered connector %s", name);
-	targetConnector = name;
+	targetConnector = connector_type_id;
 }
 
 bool drm_set_connector( struct drm_t *drm, struct connector *conn )

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -308,6 +308,7 @@ uint32_t drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_buffer *buf, struct
 void drm_lock_fbid( struct drm_t *drm, uint32_t fbid );
 void drm_unlock_fbid( struct drm_t *drm, uint32_t fbid );
 void drm_drop_fbid( struct drm_t *drm, uint32_t fbid );
+void drm_set_prefered_connector( struct drm_t *drm, char* name );
 bool drm_set_connector( struct drm_t *drm, struct connector *conn );
 bool drm_set_mode( struct drm_t *drm, const drmModeModeInfo *mode );
 bool drm_set_refresh( struct drm_t *drm, int refresh );

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -308,7 +308,7 @@ uint32_t drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_buffer *buf, struct
 void drm_lock_fbid( struct drm_t *drm, uint32_t fbid );
 void drm_unlock_fbid( struct drm_t *drm, uint32_t fbid );
 void drm_drop_fbid( struct drm_t *drm, uint32_t fbid );
-void drm_set_prefered_connector( struct drm_t *drm, char* name );
+void drm_set_prefered_connector( struct drm_t *drm, uint32_t connector_type_id );
 bool drm_set_connector( struct drm_t *drm, struct connector *conn );
 bool drm_set_mode( struct drm_t *drm, const drmModeModeInfo *mode );
 bool drm_set_refresh( struct drm_t *drm, int refresh );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5332,68 +5332,10 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 	{
 		std::vector< uint32_t > connector_ctl;
 		bool hasConnectorCtrl = get_prop( ctx, ctx->root, ctx->atoms.gamescopeConnectorControl, connector_ctl );
-		char* adapter_type;
 		if ( hasConnectorCtrl && connector_ctl.size() == 1 )
 		{
-			switch (connector_ctl[0])
-			{
-				case 0:
-					adapter_type = (char*)"eDP-1";
-					break;
-				case 1:
-					adapter_type = (char*)"eDP-2";
-					break;
-				case 2:
-					adapter_type = (char*)"eDP-3";
-					break;
-				case 3:
-					adapter_type = (char*)"DP-1";
-					break;
-				case 4:
-					adapter_type = (char*)"DP-2";
-					break;
-				case 5:
-					adapter_type = (char*)"DP-3";
-					break;
-				case 6:
-					adapter_type = (char*)"HDMI-A-1";
-					break;
-				case 7:
-					adapter_type = (char*)"HDMI-A-2";
-					break;
-				case 8:
-					adapter_type = (char*)"HDMI-A-3";
-					break;
-				case 9:
-					adapter_type = (char*)"HDMI-B-1";
-					break;
-				case 10:
-					adapter_type = (char*)"HDMI-B-2";
-					break;
-				case 11:
-					adapter_type = (char*)"HDMI-B-3";
-					break;
-				case 12:
-					adapter_type = (char*)"HDMI-C-1";
-					break;
-				case 13:
-					adapter_type = (char*)"HDMI-C-2";
-					break;
-				case 14:
-					adapter_type = (char*)"HDMI-C-3";
-					break;
-				case 15:
-					adapter_type = (char*)"DSI-1";
-					break;
-				case 16:
-					adapter_type = (char*)"DSI-2";
-					break;
-				case 17:
-					adapter_type = (char*)"DSI-3";
-					break;
-			}
 			g_DRM.out_of_date = 2;
-			drm_set_prefered_connector(&g_DRM, adapter_type);
+			drm_set_prefered_connector(&g_DRM, connector_ctl[0]);
 		}
 	}
 	if ( ev->atom == ctx->atoms.gamescopeFPSLimit )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5328,6 +5328,74 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 			}
 		}
 	}
+	if ( ev->atom == ctx->atoms.gamescopeConnectorControl )
+	{
+		std::vector< uint32_t > connector_ctl;
+		bool hasConnectorCtrl = get_prop( ctx, ctx->root, ctx->atoms.gamescopeConnectorControl, connector_ctl );
+		char* adapter_type;
+		if ( hasConnectorCtrl && connector_ctl.size() == 1 )
+		{
+			switch (connector_ctl[0])
+			{
+				case 0:
+					adapter_type = (char*)"eDP-1";
+					break;
+				case 1:
+					adapter_type = (char*)"eDP-2";
+					break;
+				case 2:
+					adapter_type = (char*)"eDP-3";
+					break;
+				case 3:
+					adapter_type = (char*)"DP-1";
+					break;
+				case 4:
+					adapter_type = (char*)"DP-2";
+					break;
+				case 5:
+					adapter_type = (char*)"DP-3";
+					break;
+				case 6:
+					adapter_type = (char*)"HDMI-A-1";
+					break;
+				case 7:
+					adapter_type = (char*)"HDMI-A-2";
+					break;
+				case 8:
+					adapter_type = (char*)"HDMI-A-3";
+					break;
+				case 9:
+					adapter_type = (char*)"HDMI-B-1";
+					break;
+				case 10:
+					adapter_type = (char*)"HDMI-B-2";
+					break;
+				case 11:
+					adapter_type = (char*)"HDMI-B-3";
+					break;
+				case 12:
+					adapter_type = (char*)"HDMI-C-1";
+					break;
+				case 13:
+					adapter_type = (char*)"HDMI-C-2";
+					break;
+				case 14:
+					adapter_type = (char*)"HDMI-C-3";
+					break;
+				case 15:
+					adapter_type = (char*)"DSI-1";
+					break;
+				case 16:
+					adapter_type = (char*)"DSI-2";
+					break;
+				case 17:
+					adapter_type = (char*)"DSI-3";
+					break;
+			}
+			g_DRM.out_of_date = 2;
+			drm_set_prefered_connector(&g_DRM, adapter_type);
+		}
+	}
 	if ( ev->atom == ctx->atoms.gamescopeFPSLimit )
 	{
 		g_nSteamCompMgrTargetFPS = get_prop( ctx, ctx->root, ctx->atoms.gamescopeFPSLimit, 0 );
@@ -6913,6 +6981,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 	ctx->atoms.gamescopeSharpness = XInternAtom( ctx->dpy, "GAMESCOPE_SHARPNESS", false );
 
 	ctx->atoms.gamescopeXWaylandModeControl = XInternAtom( ctx->dpy, "GAMESCOPE_XWAYLAND_MODE_CONTROL", false );
+	ctx->atoms.gamescopeConnectorControl = XInternAtom(ctx->dpy, "GAMESCOPE_CONNECTOR_CONTROL", false );
 	ctx->atoms.gamescopeFPSLimit = XInternAtom( ctx->dpy, "GAMESCOPE_FPS_LIMIT", false );
 	ctx->atoms.gamescopeDynamicRefresh[DRM_SCREEN_TYPE_INTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH", false );
 	ctx->atoms.gamescopeDynamicRefresh[DRM_SCREEN_TYPE_EXTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH_EXTERNAL", false );

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -142,6 +142,7 @@ struct xwayland_ctx_t
 
 		Atom gamescopeXWaylandModeControl;
 
+		Atom gamescopeConnectorControl;
 		Atom gamescopeFPSLimit;
 		Atom gamescopeDynamicRefresh[DRM_SCREEN_TYPE_COUNT];
 		Atom gamescopeLowLatency;


### PR DESCRIPTION
This will allow us to set the target display output without needing to restart gamescope.