### PR TITLE
Add GAMESCOPE_ROTATE_CONTROL atom

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -43,6 +43,7 @@ struct drm_t g_DRM = {};
 uint32_t g_nDRMFormat = DRM_FORMAT_INVALID;
 uint32_t g_nDRMFormatOverlay = DRM_FORMAT_INVALID; // for partial composition, we may have more limited formats than base planes + alpha.
 bool g_bRotated = false;
+bool g_rotate_ctl_enable = false;
 bool g_bUseLayers = true;
 bool g_bDebugLayers = false;
 const char *g_sOutputName = nullptr;
@@ -55,6 +56,7 @@ bool g_bSupportsAsyncFlips = false;
 
 enum drm_mode_generation g_drmModeGeneration = DRM_MODE_GENERATE_CVT;
 enum g_panel_orientation g_drmModeOrientation = PANEL_ORIENTATION_AUTO;
+enum g_rotate_ctl g_drmRotateCTL;
 std::atomic<uint64_t> g_drmEffectiveOrientation[DRM_SCREEN_TYPE_COUNT]{ {DRM_MODE_ROTATE_0}, {DRM_MODE_ROTATE_0} };
 
 bool g_bForceDisableColorMgmt = false;
@@ -1898,6 +1900,27 @@ static void update_drm_effective_orientation(struct drm_t *drm, struct connector
 static void update_drm_effective_orientations(struct drm_t *drm, struct connector *conn, const drmModeModeInfo *mode)
 {
 	drm_screen_type screenType = drm_get_connector_type(conn->connector);
+
+	if (g_rotate_ctl_enable)
+	{
+		switch (g_drmRotateCTL)
+		{
+			default:
+			case NORMAL:
+				g_drmEffectiveOrientation[screenType] = DRM_MODE_ROTATE_0;
+				break;
+			case LEFT_UP:
+				g_drmEffectiveOrientation[screenType] = DRM_MODE_ROTATE_90;
+				break;
+			case UPSIDEDOWN:
+				g_drmEffectiveOrientation[screenType] = DRM_MODE_ROTATE_180;
+				break;
+			case RIGHT_UP:
+				g_drmEffectiveOrientation[screenType] = DRM_MODE_ROTATE_270;
+				break;
+		}
+		return;
+	}
 	if (screenType == DRM_SCREEN_TYPE_INTERNAL)
 	{
 		update_drm_effective_orientation(drm, conn, mode);
@@ -2964,6 +2987,25 @@ bool drm_set_refresh( struct drm_t *drm, int refresh )
 	mode.type = DRM_MODE_TYPE_USERDEF;
 
 	return drm_set_mode(drm, &mode);
+}
+
+void drm_set_orientation( struct drm_t *drm, bool isRotated)
+{
+	int width = g_nOutputWidth;
+	int height = g_nOutputHeight;
+	g_bRotated = isRotated;
+	if ( g_bRotated ) {
+		int tmp = width;
+		width = height;
+		height = tmp;
+	}
+
+	if (!drm->connector || !drm->connector->connector)
+		return;
+
+	drmModeConnector *connector = drm->connector->connector;
+	const drmModeModeInfo *mode = find_mode(connector, width, height, 0);
+	update_drm_effective_orientations(drm, drm->connector, mode);
 }
 
 bool drm_set_resolution( struct drm_t *drm, int width, int height )

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -291,12 +291,23 @@ enum g_panel_orientation {
 	PANEL_ORIENTATION_AUTO,
 };
 
+enum g_rotate_ctl{
+	NORMAL,
+	LEFT_UP,
+	UPSIDEDOWN,
+	RIGHT_UP,
+};
+
 extern enum drm_mode_generation g_drmModeGeneration;
 extern enum g_panel_orientation g_drmModeOrientation;
+extern enum g_rotate_ctl g_drmRotateCTL;
+extern bool g_rotate_ctl_enable;
 
 extern std::atomic<uint64_t> g_drmEffectiveOrientation[DRM_SCREEN_TYPE_COUNT]; // DRM_MODE_ROTATE_*
 
 extern bool g_bForceDisableColorMgmt;
+
+void drm_set_orientation( struct drm_t *drm, bool isRotated );
 
 bool init_drm(struct drm_t *drm, int width, int height, int refresh, bool wants_adaptive_sync);
 void finish_drm(struct drm_t *drm);

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5321,6 +5321,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 						break;
 				}
 				drm_set_orientation(&g_DRM, rotated);
+				g_DRM.out_of_date = 2;
 			}
 	}
 	if ( ev->atom == ctx->atoms.gamescopeXWaylandModeControl )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5292,6 +5292,37 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 		if ( g_upscaleFilter == GamescopeUpscaleFilter::FSR || g_upscaleFilter == GamescopeUpscaleFilter::NIS )
 			hasRepaint = true;
 	}
+	if ( ev->atom == ctx->atoms.gamescopeRotateControl )
+	{
+			std::vector< uint32_t > drm_rot_ctl;
+			bool rotate = get_prop( ctx, ctx->root, ctx->atoms.gamescopeRotateControl, drm_rot_ctl );
+			bool rotated = false;
+			if ( rotate && drm_rot_ctl.size() == 1 )
+			{
+				xwm_log.debugf("drm_rot_ctl %d", drm_rot_ctl[0]);
+				g_rotate_ctl_enable = true;
+				switch ( drm_rot_ctl[0] )
+				{
+					case 0:
+						g_drmRotateCTL = NORMAL;
+						rotated = false;
+						break;
+					case 1:
+						g_drmRotateCTL = LEFT_UP;
+						rotated = true;
+						break;
+					case 2:
+						g_drmRotateCTL = UPSIDEDOWN;
+						rotated = false;
+						break;
+					case 3:
+						g_drmRotateCTL = RIGHT_UP;
+						rotated = true;
+						break;
+				}
+				drm_set_orientation(&g_DRM, rotated);
+			}
+	}
 	if ( ev->atom == ctx->atoms.gamescopeXWaylandModeControl )
 	{
 		std::vector< uint32_t > xwayland_mode_ctl;
@@ -6912,6 +6943,7 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 	ctx->atoms.gamescopeFSRSharpness = XInternAtom( ctx->dpy, "GAMESCOPE_FSR_SHARPNESS", false );
 	ctx->atoms.gamescopeSharpness = XInternAtom( ctx->dpy, "GAMESCOPE_SHARPNESS", false );
 
+	ctx->atoms.gamescopeRotateControl = XInternAtom( ctx->dpy, "GAMESCOPE_ROTATE_CONTROL", false );
 	ctx->atoms.gamescopeXWaylandModeControl = XInternAtom( ctx->dpy, "GAMESCOPE_XWAYLAND_MODE_CONTROL", false );
 	ctx->atoms.gamescopeFPSLimit = XInternAtom( ctx->dpy, "GAMESCOPE_FPS_LIMIT", false );
 	ctx->atoms.gamescopeDynamicRefresh[DRM_SCREEN_TYPE_INTERNAL] = XInternAtom( ctx->dpy, "GAMESCOPE_DYNAMIC_REFRESH", false );

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -140,6 +140,7 @@ struct xwayland_ctx_t
 		Atom gamescopeFSRSharpness;
 		Atom gamescopeSharpness;
 
+		Atom gamescopeRotateControl;
 		Atom gamescopeXWaylandModeControl;
 
 		Atom gamescopeFPSLimit;


### PR DESCRIPTION
This will allow us to change the orientation of the screen without needing to restart gamescope.