### PR TITLE
steamcompmgr: add env var to enable/disable 720p restriction

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -137,6 +137,9 @@ extern float g_flInternalDisplayBrightnessNits;
 extern float g_flHDRItmSdrNits;
 extern float g_flHDRItmTargetNits;
 
+// define env_to_bool to point to the function in drm: remove in later patches pl0x
+extern bool env_to_bool(const char *env);
+
 uint64_t g_lastWinSeq = 0;
 
 static std::shared_ptr<wlserver_ctm> s_scRGB709To2020Matrix;
@@ -5657,7 +5660,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 			int width = xwayland_mode_ctl[ 1 ];
 			int height = xwayland_mode_ctl[ 2 ];
 
-			if ( g_nOutputWidth != 1280 && width == 1280 )
+			if ( g_nOutputWidth != 1280 && width == 1280 && !env_to_bool( getenv("GAMESCOPE_ENABLE_720P_RESTRICT") ) )
 			{
 				width = g_nOutputWidth;
 				height = g_nOutputHeight;


### PR DESCRIPTION
This patch allows for an environment variable, `GAMESCOPE_ENABLE_720P_RESTRICT`, to be set to re-renable the 720p restriction that Steam sets, ideal for setups such as mine on Steam Deck that have scripts to auto-adjust game config files based on what's visible to `XWAYLAND1`. Disabled by default, can be set in `/etc/environment`.