### PR TITLE
Fix refresh rate control on the Legion Go

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -101,6 +101,12 @@ static uint32_t galileo_display_rates[] =
 	90,
 };
 
+static uint32_t legion_go_display_rates[] =
+{
+	60,
+	144,
+};
+
 static uint32_t get_conn_display_info_flags(struct drm_t *drm, struct connector *connector)
 {
 	if (!connector)
@@ -911,8 +917,11 @@ static void parse_edid( drm_t *drm, struct connector *conn)
 		conn->valid_display_rates = std::span(galileo_display_rates);
 	} else {
 		conn->is_galileo_display = 0;
-		if ( conn->is_steam_deck_display )
+		if ( conn->is_steam_deck_display ) {
 			conn->valid_display_rates = std::span(steam_deck_display_rates);
+		} else if ( strcmp(conn->make_pnp, "LEN") == 0 && strcmp(conn->model, "Go Display") == 0 ) {
+			conn->valid_display_rates = std::span(legion_go_display_rates);
+		}
 	}
 
 	drm_hdr_parse_edid(drm, conn, edid);


### PR DESCRIPTION
Forces the Legion Go to only use 60 or 144, and none of the invalid steps between. Allows both combined and separated frame controls in Steam Game mode to work.


https://github.com/ChimeraOS/gamescope/assets/10704358/2fa55836-db80-4926-beb9-6f44dbf2ebc5