### PR TITLE
drm: Custom refresh rates

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -842,6 +842,8 @@ void drm_update_patched_edid( drm_t *drm )
 #define GALILEO_SDC_PID 0x3003
 #define GALILEO_BOE_PID 0x3004
 
+extern std::vector<uint32_t> g_customRefreshRates;
+
 static void parse_edid( drm_t *drm, struct connector *conn)
 {
 	memset(conn->make_pnp, 0, sizeof(conn->make_pnp));
@@ -917,7 +919,9 @@ static void parse_edid( drm_t *drm, struct connector *conn)
 		conn->valid_display_rates = std::span(galileo_display_rates);
 	} else {
 		conn->is_galileo_display = 0;
-		if ( conn->is_steam_deck_display ) {
+		if ( g_customRefreshRates.size() > 0 ) {
+			conn->valid_display_rates = std::span(g_customRefreshRates);
+		} else if ( conn->is_steam_deck_display ) {
 			conn->valid_display_rates = std::span(steam_deck_display_rates);
 		} else if ( strcmp(conn->make_pnp, "LEN") == 0 && strcmp(conn->model, "Go Display") == 0 ) {
 			conn->valid_display_rates = std::span(legion_go_display_rates);

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -919,7 +919,10 @@ static void parse_edid( drm_t *drm, struct connector *conn)
 		conn->valid_display_rates = std::span(galileo_display_rates);
 	} else {
 		conn->is_galileo_display = 0;
-		if ( g_customRefreshRates.size() > 0 ) {
+		if ( g_customRefreshRates.size() > 0 && 
+			(conn->connector->connector_type == DRM_MODE_CONNECTOR_eDP ||
+					conn->connector->connector_type == DRM_MODE_CONNECTOR_LVDS ||
+					conn->connector->connector_type == DRM_MODE_CONNECTOR_DSI)) {
 			conn->valid_display_rates = std::span(g_customRefreshRates);
 		} else if ( conn->is_steam_deck_display ) {
 			conn->valid_display_rates = std::span(steam_deck_display_rates);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -683,7 +683,7 @@ int main(int argc, char **argv)
 					g_drmModeExternalOrientation = force_external_orientation( optarg );
 				} else if (strcmp(opt_name, "force-panel-type") == 0) {
 					g_drmPanelType = force_panel_type( optarg );
-				else if (strcmp(opt_name, "custom-refresh-rates") == 0) {
+				} else if (strcmp(opt_name, "custom-refresh-rates") == 0) {
 					g_customRefreshRates = parse_custom_refresh_rates( optarg );
 				} else if (strcmp(opt_name, "sharpness") == 0 ||
 						   strcmp(opt_name, "fsr-sharpness") == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "immediate-flips", no_argument, nullptr, 0 },
 	{ "adaptive-sync", no_argument, nullptr, 0 },
 	{ "framerate-limit", required_argument, nullptr, 0 },
+	{ "custom-refresh-rates", required_argument, nullptr, 0 },
 
 	// openvr options
 #if HAVE_OPENVR
@@ -183,6 +184,7 @@ const char usage[] =
 	"  --hdr-itm-target-nits          set the target luminace of the inverse tone mapping process.\n"
 	"                                 Default: 1000 nits, Max: 10000 nits\n"
 	"  --framerate-limit              Set a simple framerate limit. Used as a divisor of the refresh rate, rounds down eg 60 / 59 -> 60fps, 60 / 25 -> 30fps. Default: 0, disabled.\n"
+	"  --custom-refresh-rates         Set custom refresh rates for the output. eg: 60,90,110-120\n"	
 	"\n"
 	"Nested mode options:\n"
 	"  -o, --nested-unfocused-refresh game refresh rate when unfocused\n"
@@ -569,6 +571,32 @@ static bool CheckWaylandPresentationTime()
     return g_bSupportsWaylandPresentationTime;
 }
 
+std::vector<uint32_t> g_customRefreshRates;
+// eg: 60,60,90,110-120
+static std::vector<uint32_t> parse_custom_refresh_rates( const char *str )
+{
+	std::vector<uint32_t> rates;
+	char *token = strtok( strdup(str), ",");
+	while (token)
+	{
+		char *dash = strchr(token, '-');
+		if (dash)
+		{
+			uint32_t start = atoi(token);
+			uint32_t end = atoi(dash + 1);
+			for (uint32_t i = start; i <= end; i++)
+			{
+				rates.push_back(i);
+			}
+		}
+		else
+		{
+			rates.push_back(atoi(token));
+		}
+		token = strtok(nullptr, ",");
+	}
+	return rates;
+}
 
 int g_nPreferredOutputWidth = 0;
 int g_nPreferredOutputHeight = 0;
@@ -656,6 +684,8 @@ int main(int argc, char **argv)
 					g_drmModeExternalOrientation = force_external_orientation( optarg );
 				} else if (strcmp(opt_name, "force-panel-type") == 0) {
 					g_drmPanelType = force_panel_type( optarg );
+				else if (strcmp(opt_name, "custom-refresh-rates") == 0) {
+					g_customRefreshRates = parse_custom_refresh_rates( optarg );
 				} else if (strcmp(opt_name, "sharpness") == 0 ||
 						   strcmp(opt_name, "fsr-sharpness") == 0) {
 					g_upscaleFilterSharpness = atoi( optarg );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -572,7 +572,6 @@ static bool CheckWaylandPresentationTime()
 }
 
 std::vector<uint32_t> g_customRefreshRates;
-// eg: 60,60,90,110-120
 static std::vector<uint32_t> parse_custom_refresh_rates( const char *str )
 {
 	std::vector<uint32_t> rates;


### PR DESCRIPTION
Added a parameter --custom-refresh-rates, which allows custom refresh rates. This prevents the need to repeatedly add hard-coded refresh rate parameters for different devices.

The alternative is to use environment variables.

Not sure which solution is better.