### PR TITLE
Only change refresh rates on internal displays

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -2138,7 +2138,7 @@ namespace gamescope
 			( m_Mutable.szMakePNP == "VLV"sv && m_Mutable.szModel == "Jupiter"sv ) ||
 			( m_Mutable.szMakePNP == "VLV"sv && m_Mutable.szModel == "Galileo"sv );
 
-		if ( g_customRefreshRates.size() > 0 ) {
+		if ( g_customRefreshRates.size() > 0 && GetScreenType() == GAMESCOPE_SCREEN_TYPE_INTERNAL ) {
 					m_Mutable.ValidDynamicRefreshRates = std::span(g_customRefreshRates);
 					return;
 		}

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -2138,9 +2138,9 @@ namespace gamescope
 			( m_Mutable.szMakePNP == "VLV"sv && m_Mutable.szModel == "Jupiter"sv ) ||
 			( m_Mutable.szMakePNP == "VLV"sv && m_Mutable.szModel == "Galileo"sv );
 
-		if ( g_customRefreshRates.size() > 0 && GetScreenType() == GAMESCOPE_SCREEN_TYPE_INTERNAL ) {
-					m_Mutable.ValidDynamicRefreshRates = std::span(g_customRefreshRates);
-					return;
+		if ( g_customRefreshRates.size() > 0 && ( GetScreenType() == GAMESCOPE_SCREEN_TYPE_INTERNAL || g_bExternalForced ) ) {
+			m_Mutable.ValidDynamicRefreshRates = std::span(g_customRefreshRates);
+			return;
 		}
 		if ( bSteamDeckDisplay )
 		{


### PR DESCRIPTION
Avoids forcing refresh rates on external displays, which can often be invalid modes.