### PR TITLE
feature: add rotation shader

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -1742,7 +1742,7 @@ LiftoffStateCacheEntry FrameInfoToLiftoffStateCacheEntry( struct drm_t *drm, con
 		uint64_t crtcW = srcWidth / frameInfo->layers[ i ].scale.x;
 		uint64_t crtcH = srcHeight / frameInfo->layers[ i ].scale.y;
 
-		if (g_bRotated)
+		if (g_bRotated && !g_bUseRotationShader)
 		{
 			int64_t imageH = frameInfo->layers[ i ].tex->contentHeight() / frameInfo->layers[ i ].scale.y;
 
@@ -2035,6 +2035,16 @@ namespace gamescope
 
 	void CDRMConnector::UpdateEffectiveOrientation( const drmModeModeInfo *pMode )
 	{
+		if (g_bUseRotationShader)
+		{
+			drm_log.infof("Using rotation shader");
+			if (g_DesiredInternalOrientation == GAMESCOPE_PANEL_ORIENTATION_270) {
+				m_ChosenOrientation = GAMESCOPE_PANEL_ORIENTATION_180;
+			} else {
+				m_ChosenOrientation = GAMESCOPE_PANEL_ORIENTATION_0;
+			}
+			return;
+		}
 
 		if ( this->GetScreenType() == GAMESCOPE_SCREEN_TYPE_EXTERNAL && panelTypeChanged )
 			drm_log.infof("Display is internal faked as external");
@@ -3052,6 +3062,13 @@ bool drm_set_mode( struct drm_t *drm, const drmModeModeInfo *mode )
 		g_bRotated = false;
 		g_nOutputWidth = mode->hdisplay;
 		g_nOutputHeight = mode->vdisplay;
+
+		if (g_bUseRotationShader) {
+			g_bRotated = true;
+			g_nOutputWidth = mode->vdisplay;
+			g_nOutputHeight = mode->hdisplay;
+		}
+
 		break;
 	case GAMESCOPE_PANEL_ORIENTATION_90:
 	case GAMESCOPE_PANEL_ORIENTATION_270:
@@ -3311,6 +3328,11 @@ namespace gamescope
 
 			bNeedsFullComposite |= !!(g_uCompositeDebug & CompositeDebugFlag::Heatmap);
 
+			if (g_bUseRotationShader)
+			{
+				bNeedsFullComposite = true;
+			}
+
 			bool bDoComposite = true;
 			if ( !bNeedsFullComposite && !bWantsPartialComposite )
 			{
@@ -3401,7 +3423,7 @@ namespace gamescope
 			if ( bDefer && !!( g_uCompositeDebug & CompositeDebugFlag::Markers ) )
 				g_uCompositeDebug |= CompositeDebugFlag::Markers_Partial;
 
-			std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite );
+			std::optional oCompositeResult = vulkan_composite( &compositeFrameInfo, nullptr, !bNeedsFullComposite, nullptr, true, nullptr, g_bUseRotationShader );
 
 			m_bWasCompositing = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,6 +129,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "composite-debug", no_argument, nullptr, 0 },
 	{ "disable-xres", no_argument, nullptr, 'x' },
 	{ "fade-out-duration", required_argument, nullptr, 0 },
+	{ "use-rotation-shader", required_argument, nullptr, 0 },
 	{ "force-orientation", required_argument, nullptr, 0 },
 	{ "force-external-orientation", required_argument, nullptr, 0 },
 	{ "force-panel-type", required_argument, nullptr, 0 },
@@ -194,6 +195,7 @@ const char usage[] =
 	"  --touch-gestures               enable touch gestures for Steam menus\n"
 	"  --xwayland-count               create N xwayland servers\n"
 	"  --prefer-vk-device             prefer Vulkan device for compositing (ex: 1002:7300)\n"
+	"  --use-rotation-shader		  use rotation shader for rotating the screen\n"
 	"  --force-orientation            rotate the internal display (left, right, normal, upsidedown)\n"
 	"  --force-external-orientation   rotate the external display (left, right, normal, upsidedown)\n"
 	"  --force-panel-type             force gamescope to treat the display as either internal or external\n"
@@ -355,6 +357,8 @@ static gamescope::GamescopeModeGeneration parse_gamescope_mode_generation( const
 		exit(1);
 	}
 }
+
+bool g_bUseRotationShader = false;
 
 GamescopePanelOrientation g_DesiredInternalOrientation = GAMESCOPE_PANEL_ORIENTATION_AUTO;
 static GamescopePanelOrientation force_orientation(const char *str)
@@ -813,6 +817,8 @@ int main(int argc, char **argv)
 					gamescope::cv_touch_click_mode = (gamescope::TouchClickMode) atoi( optarg );
 				} else if (strcmp(opt_name, "generate-drm-mode") == 0) {
 					g_eGamescopeModeGeneration = parse_gamescope_mode_generation( optarg );
+				} else if (strcmp(opt_name, "use-rotation-shader") == 0) {
+					g_bUseRotationShader = true;
 				} else if (strcmp(opt_name, "force-orientation") == 0) {
 					g_DesiredInternalOrientation = force_orientation( optarg );
 				} else if (strcmp(opt_name, "force-external-orientation") == 0) {

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -22,6 +22,7 @@ extern bool g_bForceRelativeMouse;
 extern int g_nOutputRefresh; // mHz
 extern bool g_bOutputHDREnabled;
 extern bool g_bForceInternal;
+extern bool g_bUseRotationShader;
 
 extern bool g_bFullscreen;
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -70,6 +70,7 @@ shader_src = [
   'shaders/cs_nis.comp',
   'shaders/cs_nis_fp16.comp',
   'shaders/cs_rgb_to_nv12.comp',
+  'shaders/cs_rotation.comp',
 ]
 
 spirv_shaders = glsl_generator.process(shader_src)

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -390,7 +390,7 @@ gamescope::OwningRc<CVulkanTexture> vulkan_create_texture_from_dmabuf( struct wl
 gamescope::OwningRc<CVulkanTexture> vulkan_create_texture_from_bits( uint32_t width, uint32_t height, uint32_t contentWidth, uint32_t contentHeight, uint32_t drmFormat, CVulkanTexture::createFlags texCreateFlags, void *bits );
 gamescope::OwningRc<CVulkanTexture> vulkan_create_texture_from_wlr_buffer( struct wlr_buffer *buf, gamescope::OwningRc<gamescope::IBackendFb> pBackendFb );
 
-std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamescope::Rc<CVulkanTexture> pScreenshotTexture, bool partial, gamescope::Rc<CVulkanTexture> pOutputOverride = nullptr, bool increment = true, std::unique_ptr<CVulkanCmdBuffer> pInCommandBuffer = nullptr );
+std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamescope::Rc<CVulkanTexture> pScreenshotTexture, bool partial, gamescope::Rc<CVulkanTexture> pOutputOverride = nullptr, bool increment = true, std::unique_ptr<CVulkanCmdBuffer> pInCommandBuffer = nullptr, bool applyRotation = false );
 void vulkan_wait( uint64_t ulSeqNo, bool bReset );
 gamescope::Rc<CVulkanTexture> vulkan_get_last_output_image( bool partial, bool defer );
 gamescope::Rc<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace = k_EStreamColorspace_Unknown);
@@ -519,6 +519,9 @@ struct VulkanOutput_t
 	// NIS
 	gamescope::OwningRc<CVulkanTexture> nisScalerImage;
 	gamescope::OwningRc<CVulkanTexture> nisUsmImage;
+
+	// Rotated
+	gamescope::OwningRc<CVulkanTexture> rotatedOutput;
 };
 
 
@@ -531,6 +534,7 @@ enum ShaderType {
 	SHADER_TYPE_RCAS,
 	SHADER_TYPE_NIS,
 	SHADER_TYPE_RGB_TO_NV12,
+	SHADER_TYPE_ROTATION,
 
 	SHADER_TYPE_COUNT
 };

--- a/src/shaders/cs_rotation.comp
+++ b/src/shaders/cs_rotation.comp
@@ -1,0 +1,53 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+
+#include "descriptor_set.h"
+
+layout(
+    local_size_x = 8,
+    local_size_y = 8,
+    local_size_z = 1) in;
+
+#include "blit_push_data.h"
+#include "composite.h"
+
+vec4 sampleLayer(uint layerIdx, vec2 uv) {
+    if ((c_ycbcrMask & (1 << layerIdx)) != 0)
+        return sampleLayer(s_ycbcr_samplers[layerIdx], layerIdx, uv, false);
+    return sampleLayer(s_samplers[layerIdx], layerIdx, uv, true);
+}
+
+void main() {
+    uvec2 coord = uvec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
+    uvec2 outSize = imageSize(dst);
+    float outWidth = outSize.y;
+    float outHeight = outSize.x;
+
+    vec2 uv = vec2(coord);
+    vec4 outputValue = vec4(255.0f);
+
+    if (c_layerCount > 0) {
+        outputValue = sampleLayer(0, uv) * u_opacity[0];
+    }
+
+    for (int i = 1; i < c_layerCount; i++) {
+        vec4 layerColor = sampleLayer(i, uv);
+        // wl_surfaces come with premultiplied alpha, so that's them being
+        // premultiplied by layerColor.a.
+        // We need to then multiply that by the layer's opacity to get to our
+        // final premultiplied state.
+        // For the other side of things, we need to multiply by (1.0f - (layerColor.a * opacity))
+        float opacity = u_opacity[i];
+        float layerAlpha = opacity * layerColor.a;
+        outputValue = layerColor * opacity + outputValue * (1.0f - layerAlpha);
+    }
+
+    outputValue.rgb = encodeOutputColor(outputValue.rgb);
+
+    // Rotate the pixel coordinates counter-clockwise by 90 degrees
+    ivec2 rotatedCoord = ivec2(coord.y, outWidth - coord.x - 1);
+
+    imageStore(dst, rotatedCoord, outputValue);
+}

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2646,6 +2646,11 @@ static void apply_touchscreen_orientation(double *x, double *y )
         }
     }
 
+	if (g_bUseRotationShader) {
+		tx = 1.0 - *y;
+		ty = *x;
+	}
+
     *x = tx;
     *y = ty;
 }


### PR DESCRIPTION
Added a rotation shader to fix blank display problem on portrait screen with unsupported DRM rotation.

Once enabled, the DRM orientation is hardcoded to 0 degrees (left) or 180 degrees (right), and the rotation shader is hardcoded for 270 degrees rotation (counter clockwise 90 degrees)

Tested on: OneXPlayer X1 Intel

It could possibly fix an upstream issue: https://github.com/ValveSoftware/gamescope/issues/819