### PR TITLE
fix: only apply shader rotation if the screen is internal

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -3063,10 +3063,12 @@ bool drm_set_mode( struct drm_t *drm, const drmModeModeInfo *mode )
 		g_nOutputWidth = mode->hdisplay;
 		g_nOutputHeight = mode->vdisplay;
 
-		if (g_bUseRotationShader) {
+		if (g_bUseRotationShader && drm->pConnector->GetScreenType() == gamescope::GAMESCOPE_SCREEN_TYPE_INTERNAL) {
 			g_bRotated = true;
 			g_nOutputWidth = mode->vdisplay;
 			g_nOutputHeight = mode->hdisplay;
+		} else {
+			g_bUseRotationShader = false;
 		}
 
 		break;


### PR DESCRIPTION
fix: only apply shader rotation only if the screen is internal